### PR TITLE
Fixed gulp logo size in index.md

### DIFF
--- a/articles/Miscellaneous/learn-some-gulp-basics/index.md
+++ b/articles/Miscellaneous/learn-some-gulp-basics/index.md
@@ -3,7 +3,7 @@ title: Learn Some Gulp Basics
 ---
 Gulp can do **a lot**. This is just an overview of the basics. Once you understand this, then you can add more to Gulp on your own. The documentation for different packages I have used has been great and we also have a great community on FreeCodeCamp ready to help with any project.
 
-![Gulp logo](//discourse-user-assets.s3.amazonaws.com/original/2X/9/91d338cc4d22f6fa2bf415c71eca8183924419e9.jpg)
+![Gulp logo](//https://github.com/gulpjs/artwork/blob/master/gulp.png)
 
 ## What is Gulp?
 


### PR DESCRIPTION
Previous logo was too large, replaced with a copyright free gulp logo by https://github.com/gulpjs/artwork