### PR TITLE
MapReduce API

### DIFF
--- a/articles/Agile/Acceptance-Testing/index.md
+++ b/articles/Agile/Acceptance-Testing/index.md
@@ -11,4 +11,4 @@ This is a stub. [Help our community expand it.](https://github.com/freeCodeCamp/
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->
 
-
+My changes.


### PR DESCRIPTION
Hadoop provides two Java MapReduce APIs, described in more detail in “The old and the new Java MapReduce APIs” on page 27. This edition of the book uses the new API, which will work with all versions listed here, except in a few cases where that part of the new API is not available in the 1.x releases.